### PR TITLE
chore(deps): pin eslint to v8

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -93,8 +93,9 @@ project.addDevDeps(
   "change-case",
   "@action-validator/core",
   "@action-validator/cli",
-  // @typescript-eslint v7+ requires Node.js 18.18, so we are stuck on v6
+  // eslint v9+ and @typescript-eslint v7+ require Node.js 18.18, so we are stuck on v8 and v6 respectively
   // The below lines can probably be removed once Node 18 goes EOL and we upgrade minNodeVersion to 20
+  "eslint@^8",
   "@typescript-eslint/eslint-plugin@^6",
   "@typescript-eslint/parser@^6"
 );


### PR DESCRIPTION
v9 requires Node 18.18+ while our minNodeVersion is purposely set to 18.12. The easiest fix is to avoid upgrading eslint for now.